### PR TITLE
feat(logging): 요청 단위 추적을 위한 MDC 필터 및 로그 설정 추가

### DIFF
--- a/app-api/src/main/java/com/tp/appapi/common/logging/MdcFilter.java
+++ b/app-api/src/main/java/com/tp/appapi/common/logging/MdcFilter.java
@@ -1,0 +1,69 @@
+package com.tp.appapi.common.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class MdcFilter extends OncePerRequestFilter {
+
+    private static final String HDR_X_REQUEST_ID = "X-Request-Id";
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String traceId = extractTraceId(request);
+        MDC.put("traceId", traceId);
+        MDC.put("userId", resolveUserId());
+        MDC.put("clientIp", resolveClientIp(request));
+        MDC.put("reqUri", request.getRequestURI());
+        MDC.put("reqMethod", request.getMethod());
+        response.setHeader(HDR_X_REQUEST_ID, traceId);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    private String extractTraceId(HttpServletRequest req) {
+        String h = headerFirstNonBlank(req, HDR_X_REQUEST_ID);
+        return (h != null) ? h : UUID.randomUUID().toString();
+    }
+
+    private String headerFirstNonBlank(HttpServletRequest req, String... names) {
+        for (String n : names) {
+            String v = req.getHeader(n);
+            if (v != null && !v.isBlank()) return v;
+        }
+        return null;
+    }
+
+    private String resolveUserId() {
+        // TODO: SecurityContext에서 실제 사용자 ID 추출
+        return "system";
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        // 프록시/ALB 환경 고려
+        String xff = request.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isBlank()) {
+            // "client, proxy1, proxy2" 형태 → 첫번째가 클라이언트 IP
+            return xff.split(",")[0].trim();
+        }
+        String realIp = request.getHeader("X-Real-IP");
+        if (realIp != null && !realIp.isBlank()) return realIp;
+        return request.getRemoteAddr();
+    }
+}

--- a/app-api/src/main/resources/application-local.yml
+++ b/app-api/src/main/resources/application-local.yml
@@ -2,3 +2,5 @@ spring:
   config:
     import:
       - "classpath:application-domain-local.yml"
+logging:
+  config: classpath:logback-local-spring.xml

--- a/app-api/src/main/resources/application-prod.yml
+++ b/app-api/src/main/resources/application-prod.yml
@@ -2,3 +2,5 @@ spring:
   config:
     import:
       - "classpath:application-domain-prod.yml"
+logging:
+  config: classpath:logback-prod-spring.xml

--- a/app-api/src/main/resources/logback-local-spring.xml
+++ b/app-api/src/main/resources/logback-local-spring.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+
+    <!-- 공통 패턴 -->
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg | traceId=%X{traceId} userId=%X{userId} clientIp=%X{clientIp} uri=%X{reqUri} method=%X{reqMethod} status=%X{respStatus}%n"/>
+
+    <!-- 콘솔 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 패키지 별 레벨 조절 (필요 시) -->
+    <logger name="org.hibernate.SQL" level="INFO"/>
+    <logger name="org.springframework" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/app-api/src/main/resources/logback-prod-spring.xml
+++ b/app-api/src/main/resources/logback-prod-spring.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name" defaultValue="app-api"/>
+
+    <!-- 공통 패턴 -->
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg | traceId=%X{traceId} userId=%X{userId} clientIp=%X{clientIp} uri=%X{reqUri} method=%X{reqMethod} status=%X{respStatus}%n"/>
+
+    <!-- 콘솔 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 파일 롤링 -->
+    <appender name="APP_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/var/log/${APP_NAME}/application.log</file>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>/var/log/${APP_NAME}/application.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>200MB</maxFileSize>
+            <maxHistory>14</maxHistory>
+            <totalSizeCap>5GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <!-- 비동기 (I/O 분리) -->
+    <appender name="ASYNC_APP" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="APP_FILE"/>
+        <queueSize>8192</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
+    </appender>
+
+    <!-- 패키지 별 레벨 조절 (필요 시) -->
+    <logger name="org.hibernate.SQL" level="INFO"/>
+    <logger name="org.springframework" level="INFO"/>
+
+    <!-- profile 별로 콘솔/파일 조합 -->
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="ASYNC_APP"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
- MdcFilter 추가: 요청 진입 시 MDC에 traceId, userId, clientIp, URI, method 저장
- 응답 완료 시 MDC.clear()로 ThreadLocal 누수 방지
- logback-spring.xml 패턴에 MDC 필드(traceId, userId, clientIp 등) 포함
- API 호출별 traceId 기반의 로그 추적 가능하도록 개선